### PR TITLE
Veba devel Edits by Jarrod

### DIFF
--- a/install/environments/VEBA-cluster_env.yml
+++ b/install/environments/VEBA-cluster_env.yml
@@ -114,7 +114,7 @@ dependencies:
   - xz=5.2.6=h166bdaf_0
   - zlib=1.2.13=h166bdaf_4
   - zstd=1.5.5=hfc55251_0
-    - pip:
+  - pip:
       - memory-profiler==0.61.0
       - psutil==6.1.1
       - pyexeggutor==2025.1.23.post2

--- a/install/environments/VEBA-mapping_env.yml
+++ b/install/environments/VEBA-mapping_env.yml
@@ -82,7 +82,7 @@ dependencies:
   - xz=5.2.6=h166bdaf_0
   - zlib=1.2.13=hd590300_5
   - zstd=1.5.5=hfc55251_0
-    - pip:
+  - pip:
       - memory-profiler==0.61.0
       - psutil==6.1.1
       - pyexeggutor==2025.1.23.post2

--- a/install/install.sh
+++ b/install/install.sh
@@ -24,7 +24,7 @@ conda install -c conda-forge mamba -y
 echo "Creating ${VEBA} main environment"
 
 ENV_NAME="VEBA"
-(mamba create -y -p ${CONDA_ENVS_PATH}/${ENV_NAME} -c conda-forge -c bioconda -c jolespin parallelseqkit genopype networkx biopython biom-format anndata || echo "Error when creating main VEBA environment" ; exit 1) &> ${LOG_DIRECTORY}/VEBA.log
+(mamba create -y -p ${CONDA_ENVS_PATH}/${ENV_NAME} -c conda-forge -c bioconda -c jolespin parallel seqkit genopype networkx biopython biom-format anndata || echo "Error when creating main VEBA environment" ; exit 1) &> ${LOG_DIRECTORY}/VEBA.log
 
 # Copy main executable
 echo -e "\t*Copying main VEBA executable into ${ENV_NAME} environment path"


### PR DESCRIPTION
Files modified:

`install/install.sh`Line 27:  changed  `parallelseqkit` to `parallel seqkit`. This solved an error installing the `VEBA` base directory
`install/environments/VEBA-cluster_env.yml`: Line 117 Removed  indent before `pip`. Solves error installing `VEBA-cluster_env.`
`install/environments/VEBA-mapping_env.yml` : Line 85 Removed  indent before `pip`. Solves error installing `VEBA-mapping_env.`
